### PR TITLE
Fix build configuration and DuckDB secrets and extension loading

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,9 +29,8 @@ jar {
     }
     from {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
-    }
-    {
-        exclude("META-INF/*.SF")
+    } {
+        exclude("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA")
     }
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }

--- a/src/main/java/com/google/db3/GcsToAlloyDb.java
+++ b/src/main/java/com/google/db3/GcsToAlloyDb.java
@@ -71,13 +71,18 @@ public class GcsToAlloyDb {
       statement.execute(
           String.format(
               "CREATE SECRET alloydb (TYPE postgres, HOST '%s', PORT %d, DATABASE %s, USER '%s', PASSWORD '%s')",
-              alloyDbIp, alloyDbPort, alloyDbDatabase, alloyDbUser, alloyDbPassword));
+              alloyDbIp, alloyDbPort, alloyDbDatabase, alloyDbUser, alloyDbPassword.replace("'", "''")));
       System.out.println("AlloyDB secret created.");
+
+      // Load httpfs extension
+      statement.execute("INSTALL httpfs;");
+      statement.execute("LOAD httpfs;");
+      System.out.println("httpfs extension installed and loaded.");
 
       // Create a Google Cloud Storage secret
       statement.execute(
           String.format(
-              "CREATE SECRET gcs (TYPE gcs, KEY_ID '%s', SECRET '%s')", gcsKeyId, gcsSecret));
+              "CREATE SECRET gcs (TYPE gcs, KEY_ID '%s', SECRET '%s')", gcsKeyId, gcsSecret.replace("'", "''")));
       System.out.println("Google Cloud Storage secret created.");
 
       // Connect to AlloyDB


### PR DESCRIPTION
- Update build.gradle to exclude all META-INF signature files (*.DSA, *.RSA, *.SF) when building the fat JAR to prevent runtime SecurityExceptions.
- Install and load DuckDB `httpfs` extension before creating GCS secrets, which is required for DuckDB to interact with Google Cloud Storage.
- Escape single quotes in DuckDB secret strings (passwords) to prevent SQL syntax errors or potential SQL injection when running `CREATE SECRET`.

---
*PR created automatically by Jules for task [12647129327290828707](https://jules.google.com/task/12647129327290828707) started by @nasmart*