### PR TITLE
🔒 Fix SQL Injection in BigQueryToGcs EXPORT DATA query

### DIFF
--- a/src/main/java/com/google/db3/BigQueryToGcs.java
+++ b/src/main/java/com/google/db3/BigQueryToGcs.java
@@ -27,6 +27,20 @@ public class BigQueryToGcs {
     exportDataToGCS(datasetProjectId, gcsUri, datasetId, tableId);
   }
 
+  private static String escapeSqlString(String value) {
+    if (value == null) {
+      return null;
+    }
+    return value.replace("\\", "\\\\").replace("'", "\\'");
+  }
+
+  private static String escapeIdentifier(String value) {
+    if (value == null) {
+      return null;
+    }
+    return value.replace("\\", "\\\\").replace("`", "\\`");
+  }
+
   private static void exportDataToGCS(
       String datasetProjectId, String gcsUri, String datasetId, String tableId)
       throws InterruptedException {
@@ -42,8 +56,11 @@ public class BigQueryToGcs {
                   + "  overwrite=true,"
                   + "  compression='SNAPPY'"
                   + ") AS SELECT * "
-                  + "  FROM %s.%s.%s",
-              gcsUri, datasetProjectId, datasetId, tableId);
+                  + "  FROM `%s`.`%s`.`%s`",
+              escapeSqlString(gcsUri),
+              escapeIdentifier(datasetProjectId),
+              escapeIdentifier(datasetId),
+              escapeIdentifier(tableId));
 
       QueryJobConfiguration queryConfig = QueryJobConfiguration.newBuilder(query).build();
 


### PR DESCRIPTION
🎯 **What:** Fixed an SQL injection vulnerability in the `BigQueryToGcs.java` file where the `EXPORT DATA` query was constructed with unescaped user-controlled inputs.
⚠️ **Risk:** An attacker could control environment variables like `BIGQUERY_PROJECT` or `GCS_BUCKET` to inject malicious SQL commands into the BigQuery DDL query, potentially allowing unauthorized data access, exfiltration, or manipulation.
🛡️ **Solution:** Implemented explicit escaping for both SQL string literals (used for the URI) and SQL identifiers (used for dataset/table names) before interpolating them into the string. Identifiers are properly wrapped with backticks, securing the DDL query without regressions.

---
*PR created automatically by Jules for task [6555686272744551054](https://jules.google.com/task/6555686272744551054) started by @nasmart*