### PR TITLE
🔒 Fix SQL Injection in AlloyDB Secret Creation and COPY statements

### DIFF
--- a/src/main/java/com/google/db3/GcsToAlloyDb.java
+++ b/src/main/java/com/google/db3/GcsToAlloyDb.java
@@ -71,13 +71,13 @@ public class GcsToAlloyDb {
       statement.execute(
           String.format(
               "CREATE SECRET alloydb (TYPE postgres, HOST '%s', PORT %d, DATABASE '%s', USER '%s', PASSWORD '%s')",
-              escapeSql(alloyDbIp), alloyDbPort, escapeSql(alloyDbDatabase), escapeSql(alloyDbUser), escapeSql(alloyDbPassword)));
+              escapeSqlString(alloyDbIp), alloyDbPort, escapeSqlString(alloyDbDatabase), escapeSqlString(alloyDbUser), escapeSqlString(alloyDbPassword)));
       System.out.println("AlloyDB secret created.");
 
       // Create a Google Cloud Storage secret
       statement.execute(
           String.format(
-              "CREATE SECRET gcs (TYPE gcs, KEY_ID '%s', SECRET '%s')", escapeSql(gcsKeyId), escapeSql(gcsSecret)));
+              "CREATE SECRET gcs (TYPE gcs, KEY_ID '%s', SECRET '%s')", escapeSqlString(gcsKeyId), escapeSqlString(gcsSecret)));
       System.out.println("Google Cloud Storage secret created.");
 
       // Connect to AlloyDB
@@ -92,7 +92,7 @@ public class GcsToAlloyDb {
           String file = String.format("%s/%012d.parquet", gcsUri, i);
           statement.execute(
               String.format(
-                  "COPY alloydb.%s.%s FROM '%s' (FORMAT parquet)", alloyDbSchema, alloyDbTableId, file));
+                  "COPY alloydb.%s.%s FROM '%s' (FORMAT parquet)", escapeIdentifier(alloyDbSchema), escapeIdentifier(alloyDbTableId), escapeSqlString(file)));
           System.out.println(String.format("Loaded %s to AlloyDB.", file));
         }
       }
@@ -103,11 +103,18 @@ public class GcsToAlloyDb {
     } 
   }
 
-  private static String escapeSql(String input) {
+  private static String escapeSqlString(String input) {
     if (input == null) {
       return null;
     }
-    return input.replace("'", "''");
+    return input.replace("\\", "\\\\").replace("'", "''");
+  }
+
+  private static String escapeIdentifier(String input) {
+    if (input == null) {
+      return null;
+    }
+    return "\"" + input.replace("\"", "\"\"") + "\"";
   }
 
   public static int countFiles(String bucketName, String prefix) {


### PR DESCRIPTION
🎯 **What:** Fixed an SQL injection vulnerability in `GcsToAlloyDb.java` where untrusted environment variables (like passwords, keys, and table names) were directly concatenated into `CREATE SECRET` and `COPY` SQL commands.

⚠️ **Risk:** If an attacker controls any of the environment variables (like `ALLOYDB_PASSWORD`, `GCS_SECRET`, or `ALLOYDB_SCHEMA`), they could inject malicious SQL commands, leading to unauthorized data access or modification within the DuckDB/AlloyDB instances.

🛡️ **Solution:** DuckDB JDBC does not support `PreparedStatement` parameters (`?`) for DDL commands. Therefore, the fix implements robust manual string escaping (`escapeSqlString`, which properly handles both `\` and `'`) and identifier escaping (`escapeIdentifier`, which wraps identifiers in `"` and escapes internal `"`). These methods are applied to all dynamically injected values in `CREATE SECRET` and `COPY` commands to prevent injection attacks.

---
*PR created automatically by Jules for task [16796223674610825568](https://jules.google.com/task/16796223674610825568) started by @nasmart*