### PR TITLE
🧹 Extract SQL escaping methods into SqlUtils utility class

### DIFF
--- a/src/main/java/com/google/db3/BigQueryToGcs.java
+++ b/src/main/java/com/google/db3/BigQueryToGcs.java
@@ -27,20 +27,6 @@ public class BigQueryToGcs {
     exportDataToGCS(datasetProjectId, gcsUri, datasetId, tableId);
   }
 
-  private static String escapeSqlString(String value) {
-    if (value == null) {
-      return null;
-    }
-    return value.replace("\\", "\\\\").replace("'", "\\'");
-  }
-
-  private static String escapeIdentifier(String value) {
-    if (value == null) {
-      return null;
-    }
-    return value.replace("\\", "\\\\").replace("`", "\\`");
-  }
-
   private static void exportDataToGCS(
       String datasetProjectId, String gcsUri, String datasetId, String tableId)
       throws InterruptedException {
@@ -57,10 +43,10 @@ public class BigQueryToGcs {
                   + "  compression='SNAPPY'"
                   + ") AS SELECT * "
                   + "  FROM `%s`.`%s`.`%s`",
-              escapeSqlString(gcsUri),
-              escapeIdentifier(datasetProjectId),
-              escapeIdentifier(datasetId),
-              escapeIdentifier(tableId));
+              SqlUtils.escapeBigQuerySqlString(gcsUri),
+              SqlUtils.escapeBigQueryIdentifier(datasetProjectId),
+              SqlUtils.escapeBigQueryIdentifier(datasetId),
+              SqlUtils.escapeBigQueryIdentifier(tableId));
 
       QueryJobConfiguration queryConfig = QueryJobConfiguration.newBuilder(query).build();
 

--- a/src/main/java/com/google/db3/GcsToAlloyDb.java
+++ b/src/main/java/com/google/db3/GcsToAlloyDb.java
@@ -71,13 +71,13 @@ public class GcsToAlloyDb {
       statement.execute(
           String.format(
               "CREATE SECRET alloydb (TYPE postgres, HOST '%s', PORT %d, DATABASE '%s', USER '%s', PASSWORD '%s')",
-              escapeSqlString(alloyDbIp), alloyDbPort, escapeSqlString(alloyDbDatabase), escapeSqlString(alloyDbUser), escapeSqlString(alloyDbPassword)));
+              SqlUtils.escapeDuckDbSqlString(alloyDbIp), alloyDbPort, SqlUtils.escapeDuckDbSqlString(alloyDbDatabase), SqlUtils.escapeDuckDbSqlString(alloyDbUser), SqlUtils.escapeDuckDbSqlString(alloyDbPassword)));
       System.out.println("AlloyDB secret created.");
 
       // Create a Google Cloud Storage secret
       statement.execute(
           String.format(
-              "CREATE SECRET gcs (TYPE gcs, KEY_ID '%s', SECRET '%s')", escapeSqlString(gcsKeyId), escapeSqlString(gcsSecret)));
+              "CREATE SECRET gcs (TYPE gcs, KEY_ID '%s', SECRET '%s')", SqlUtils.escapeDuckDbSqlString(gcsKeyId), SqlUtils.escapeDuckDbSqlString(gcsSecret)));
       System.out.println("Google Cloud Storage secret created.");
 
       // Connect to AlloyDB
@@ -92,7 +92,7 @@ public class GcsToAlloyDb {
           String file = String.format("%s/%012d.parquet", gcsUri, i);
           statement.execute(
               String.format(
-                  "COPY alloydb.%s.%s FROM '%s' (FORMAT parquet)", escapeIdentifier(alloyDbSchema), escapeIdentifier(alloyDbTableId), escapeSqlString(file)));
+                  "COPY alloydb.%s.%s FROM '%s' (FORMAT parquet)", SqlUtils.escapeDuckDbIdentifier(alloyDbSchema), SqlUtils.escapeDuckDbIdentifier(alloyDbTableId), SqlUtils.escapeDuckDbSqlString(file)));
           System.out.println(String.format("Loaded %s to AlloyDB.", file));
         }
       }
@@ -101,20 +101,6 @@ public class GcsToAlloyDb {
       System.err.println("Error: " + e.getMessage());
       e.printStackTrace();
     } 
-  }
-
-  private static String escapeSqlString(String input) {
-    if (input == null) {
-      return null;
-    }
-    return input.replace("\\", "\\\\").replace("'", "''");
-  }
-
-  private static String escapeIdentifier(String input) {
-    if (input == null) {
-      return null;
-    }
-    return "\"" + input.replace("\"", "\"\"") + "\"";
   }
 
   public static int countFiles(String bucketName, String prefix) {

--- a/src/main/java/com/google/db3/SqlUtils.java
+++ b/src/main/java/com/google/db3/SqlUtils.java
@@ -1,0 +1,36 @@
+package com.google.db3;
+
+/** Utility class for SQL string escaping. */
+public final class SqlUtils {
+  private SqlUtils() {
+    // Prevent instantiation
+  }
+
+  public static String escapeBigQuerySqlString(String value) {
+    if (value == null) {
+      return null;
+    }
+    return value.replace("\\", "\\\\").replace("'", "\\'");
+  }
+
+  public static String escapeBigQueryIdentifier(String value) {
+    if (value == null) {
+      return null;
+    }
+    return value.replace("\\", "\\\\").replace("`", "\\`");
+  }
+
+  public static String escapeDuckDbSqlString(String input) {
+    if (input == null) {
+      return null;
+    }
+    return input.replace("\\", "\\\\").replace("'", "''");
+  }
+
+  public static String escapeDuckDbIdentifier(String input) {
+    if (input == null) {
+      return null;
+    }
+    return "\"" + input.replace("\"", "\"\"") + "\"";
+  }
+}


### PR DESCRIPTION
🎯 **What:** Extracted duplicated string and identifier escaping methods from `BigQueryToGcs.java` and `GcsToAlloyDb.java` into a centralized `SqlUtils.java` utility class.

💡 **Why:** Reduces code duplication and centralizes dialect-specific logic (DuckDB vs BigQuery escaping mechanisms), improving code maintainability.

✅ **Verification:** Verified the code compiles successfully without regressions using Gradle. The code cleanly abstracts the differently escaped dialects to ensure safety during refactor.

✨ **Result:** A more maintainable and cleaner codebase where SQL escaping functionalities are centralized in a single utility class.

---
*PR created automatically by Jules for task [13916673224016752983](https://jules.google.com/task/13916673224016752983) started by @nasmart*