### PR TITLE
Restore Config.java to read from properties file

### DIFF
--- a/src/main/java/com/google/db3/BigQueryToGcs.java
+++ b/src/main/java/com/google/db3/BigQueryToGcs.java
@@ -17,11 +17,11 @@ public class BigQueryToGcs {
 
   public static void main(String[] args) throws InterruptedException {
 
-    String datasetProjectId = System.getenv("BIGQUERY_PROJECT");
-    String datasetId = System.getenv("BIGQUERY_DATASET");
-    String tableId = System.getenv("BIGQUERY_TABLE");
-    String bucketName = System.getenv("GCS_BUCKET");
-    String prefix = System.getenv("GCS_PREFIX");
+    String datasetProjectId = Config.get("BIGQUERY_PROJECT");
+    String datasetId = Config.get("BIGQUERY_DATASET");
+    String tableId = Config.get("BIGQUERY_TABLE");
+    String bucketName = Config.get("GCS_BUCKET");
+    String prefix = Config.get("GCS_PREFIX");
     String gcsUri = String.format("gs://%s/%s", bucketName, prefix);
 
     exportDataToGCS(datasetProjectId, gcsUri, datasetId, tableId);

--- a/src/main/java/com/google/db3/Config.java
+++ b/src/main/java/com/google/db3/Config.java
@@ -1,0 +1,36 @@
+package com.google.db3;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class Config {
+
+  private static final Properties properties = new Properties();
+
+  static {
+    String configFile = System.getenv("CONFIG_FILE");
+    if (configFile == null) {
+      configFile = "config.properties";
+    }
+
+    try (InputStream input = new FileInputStream(configFile)) {
+      properties.load(input);
+    } catch (IOException ex) {
+      // If a specific config file was requested and failed, log it.
+      if (System.getenv("CONFIG_FILE") != null) {
+        System.err.println("Warning: Unable to load config file " + configFile + ": " + ex.getMessage());
+      }
+      // If default config.properties doesn't exist, we just rely on environment variables.
+    }
+  }
+
+  public static String get(String key) {
+    String envValue = System.getenv(key);
+    if (envValue != null) {
+      return envValue;
+    }
+    return properties.getProperty(key);
+  }
+}

--- a/src/main/java/com/google/db3/GcsToAlloyDb.java
+++ b/src/main/java/com/google/db3/GcsToAlloyDb.java
@@ -15,20 +15,20 @@ public class GcsToAlloyDb {
 
   public static void main(String[] args) throws InterruptedException {
 
-    String bucketName = System.getenv("GCS_BUCKET");
-    String prefix = System.getenv("GCS_PREFIX");
+    String bucketName = Config.get("GCS_BUCKET");
+    String prefix = Config.get("GCS_PREFIX");
     String gcsUri = String.format("gs://%s/%s", bucketName, prefix);
 
-    String alloyDbIp = System.getenv("ALLOYDB_IP");
-    String alloyDbPortStr = System.getenv("ALLOYDB_PORT");
-    String alloyDbDatabase = System.getenv("ALLOYDB_DATABASE");
-    String alloyDbSchema = System.getenv("ALLOYDB_SCHEMA");
-    String alloyDbTableId = System.getenv("ALLOYDB_TABLE");
-    String alloyDbUser = System.getenv("ALLOYDB_USER");
-    String alloyDbPassword = System.getenv("ALLOYDB_PASSWORD");
+    String alloyDbIp = Config.get("ALLOYDB_IP");
+    String alloyDbPortStr = Config.get("ALLOYDB_PORT");
+    String alloyDbDatabase = Config.get("ALLOYDB_DATABASE");
+    String alloyDbSchema = Config.get("ALLOYDB_SCHEMA");
+    String alloyDbTableId = Config.get("ALLOYDB_TABLE");
+    String alloyDbUser = Config.get("ALLOYDB_USER");
+    String alloyDbPassword = Config.get("ALLOYDB_PASSWORD");
 
-    String gcsKeyId = System.getenv("GCS_KEY_ID");
-    String gcsSecret = System.getenv("GCS_SECRET");
+    String gcsKeyId = Config.get("GCS_KEY_ID");
+    String gcsSecret = Config.get("GCS_SECRET");
 
     int totalWorkers;
     int workerId;


### PR DESCRIPTION
Restores the usage of Config.get() instead of System.getenv() to allow reading configuration from a properties file as well. This restores changes from PR 11 which had been previously reverted.

---
*PR created automatically by Jules for task [2244898498005983945](https://jules.google.com/task/2244898498005983945) started by @nasmart*